### PR TITLE
Update copyright notices.

### DIFF
--- a/src/main/java/dev/austech/betterreports/utils/Common.java
+++ b/src/main/java/dev/austech/betterreports/utils/Common.java
@@ -7,8 +7,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2020 Tim Uding.
- * Copyright (c) 2020 Contributors.
+ * Copyright (c) 2020 Joshua Sing & Tim Uding.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the
  * "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute,


### PR DESCRIPTION
I don't recommend copyrighting to "Contributors" as it isn't really referring to everyone that has contributed, instead, please follow the following:

When someone edits more than 10% of a file, they can add their **Full Name** to the copyright notice in the top of the file.
When someone creates a file, they can add their **Full Name** to the copyright notice in the top of the file.

Thanks, Joshua Sing.